### PR TITLE
[API] RF05

### DIFF
--- a/api/__tests__/services/podcasts.service.test.ts
+++ b/api/__tests__/services/podcasts.service.test.ts
@@ -41,5 +41,36 @@ describe('PodcastsService', () => {
     jest.spyOn(podcastsRepository, 'listByUserId').mockReturnValueOnce(Promise.resolve([]) as any);
 
     expect(await podcastsService.listPodcastsByUser(userId)).toEqual([]);
-  })
+  });
+
+  it('should get podcast by id', async () => {
+    const podcastId = 1;
+
+    const podcast = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      publishedAt: new Date(),
+      fileUrl: 'http://test.com/test.mp3',
+      duration: 4237,
+      userId: 1,
+    };
+
+    jest.spyOn(podcastsRepository, 'getById').mockReturnValueOnce(Promise.resolve(podcast) as any);
+
+    expect(await podcastsService.getPodcastById(podcastId)).toEqual(podcast);
+  });
+
+  it('should throw exception when podcast not found', async () => {
+    const podcastId = 1;
+
+    jest.spyOn(podcastsRepository, 'getById').mockReturnValueOnce(Promise.resolve(null) as any);
+
+    try {
+      await podcastsService.getPodcastById(podcastId);
+    } catch (error: any) {
+      expect(error.statusCode).toEqual(404);
+      expect(error.message).toEqual('Podcast not found');
+    }
+  });
 });

--- a/api/__tests__/services/podcasts.service.test.ts
+++ b/api/__tests__/services/podcasts.service.test.ts
@@ -45,6 +45,7 @@ describe('PodcastsService', () => {
 
   it('should get podcast by id', async () => {
     const podcastId = 1;
+    const userId = 1;
 
     const podcast = {
       id: 1,
@@ -58,19 +59,44 @@ describe('PodcastsService', () => {
 
     jest.spyOn(podcastsRepository, 'getById').mockReturnValueOnce(Promise.resolve(podcast) as any);
 
-    expect(await podcastsService.getPodcastById(podcastId)).toEqual(podcast);
+    expect(await podcastsService.getPodcastById(userId, podcastId)).toEqual(podcast);
   });
 
   it('should throw exception when podcast not found', async () => {
     const podcastId = 1;
+    const userId = 1;
 
     jest.spyOn(podcastsRepository, 'getById').mockReturnValueOnce(Promise.resolve(null) as any);
 
     try {
-      await podcastsService.getPodcastById(podcastId);
+      await podcastsService.getPodcastById(userId, podcastId);
     } catch (error: any) {
       expect(error.statusCode).toEqual(404);
       expect(error.message).toEqual('Podcast not found');
     }
   });
+
+  it('should throw exception when podcast is not linked to user', async () => {
+    const podcastId = 1;
+    const userId = 1;
+
+    const podcast = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      publishedAt: new Date(),
+      fileUrl: 'http://test.com/test.mp3',
+      duration: 4237,
+      userId: 2,
+    };
+
+    jest.spyOn(podcastsRepository, 'getById').mockReturnValueOnce(Promise.resolve(podcast) as any);
+
+    try {
+      await podcastsService.getPodcastById(userId, podcastId);
+    } catch (error: any) {
+      expect(error.statusCode).toEqual(403);
+      expect(error.message).toEqual('This podcast is not linked to your account');
+    }
+  })
 });

--- a/api/src/controllers/PodcastsController.ts
+++ b/api/src/controllers/PodcastsController.ts
@@ -19,7 +19,7 @@ const listPodcastsByUser = async (req: Request, res: Response) => {
 const getPodcastById = async (req: Request, res: Response) => {
   const { podcastId } = req.params;
   try {
-    const podcast = await podcastsService.getPodcastById(Number(podcastId));
+    const podcast = await podcastsService.getPodcastById(req.userId, Number(podcastId));
     res.status(200).send(podcast);
   } catch (error: any) {
     res.status(error.statusCode).send({

--- a/api/src/controllers/PodcastsController.ts
+++ b/api/src/controllers/PodcastsController.ts
@@ -16,6 +16,22 @@ const listPodcastsByUser = async (req: Request, res: Response) => {
   }
 };
 
+const getPodcastById = async (req: Request, res: Response) => {
+  const { podcastId } = req.params;
+  try {
+    const podcast = await podcastsService.getPodcastById(Number(podcastId));
+    res.status(200).send(podcast);
+  } catch (error: any) {
+    res.status(error.statusCode).send({
+      error: {
+        statusCode: error.statusCode,
+        message: error.message,
+      },
+    });
+  }
+};
+
 export default {
   listPodcastsByUser,
+  getPodcastById,
 };

--- a/api/src/repositories/podcasts.repository.ts
+++ b/api/src/repositories/podcasts.repository.ts
@@ -4,6 +4,11 @@ const listByUserId = async (userId: number) => {
   return Podcast.findAll({ where: { userId } });
 };
 
+const getById = async (podcastId: number) => {
+  return Podcast.findOne({ where: { id: podcastId } });
+};
+
 export default {
   listByUserId,
+  getById,
 };

--- a/api/src/routes/podcasts.routes.ts
+++ b/api/src/routes/podcasts.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import PodcastsController from '../controllers/PodcastsController';
 import { authValidator } from '../validations/auth/auth.validator';
+import { getPodcastByIdValidator } from '../validations/podcasts/getPodcastById.validator';
 import { listPodcastsByUserValidator } from '../validations/podcasts/listPodcastsByUser.validator';
 
 const router = express.Router();
@@ -8,5 +9,6 @@ const router = express.Router();
 router.use(authValidator);
 
 router.get('/', listPodcastsByUserValidator, PodcastsController.listPodcastsByUser);
+router.get('/:podcastId', getPodcastByIdValidator, PodcastsController.getPodcastById);
 
 export default router;

--- a/api/src/services/podcasts.service.ts
+++ b/api/src/services/podcasts.service.ts
@@ -1,10 +1,24 @@
 import podcastsRepository from '../repositories/podcasts.repository';
+import { Exception } from '../utils/exception';
 
 const listPodcastsByUser = async (userId: number) => {
   const podcasts = await podcastsRepository.listByUserId(userId);
   return podcasts;
 };
 
+const getPodcastById = async (podcastId: number) => {
+  const podcast = await podcastsRepository.getById(podcastId);
+  if (!podcast) {
+    throw new Exception({
+      status: 404,
+      message: 'Podcast not found',
+    });
+  }
+
+  return podcast;
+};
+
 export default {
   listPodcastsByUser,
+  getPodcastById,
 };

--- a/api/src/services/podcasts.service.ts
+++ b/api/src/services/podcasts.service.ts
@@ -6,12 +6,19 @@ const listPodcastsByUser = async (userId: number) => {
   return podcasts;
 };
 
-const getPodcastById = async (podcastId: number) => {
+const getPodcastById = async (userId: number, podcastId: number) => {
   const podcast = await podcastsRepository.getById(podcastId);
   if (!podcast) {
     throw new Exception({
       status: 404,
       message: 'Podcast not found',
+    });
+  }
+
+  if (podcast.userId !== userId) {
+    throw new Exception({
+      status: 403,
+      message: 'This podcast is not linked to your account',
     });
   }
 

--- a/api/src/validations/podcasts/getPodcastById.validator.ts
+++ b/api/src/validations/podcasts/getPodcastById.validator.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+import Joi from 'joi';
+
+export const getPodcastByIdValidator = (req: Request, res: Response, next: NextFunction) => {
+  const schema = Joi.object({
+    podcastId: Joi.number().required(),
+  });
+
+  const { error } = schema.validate(req.params, { abortEarly: false, allowUnknown: true, stripUnknown: true });
+
+  if (error) {
+    return res.status(400).send({
+      error: {
+        statusCode: 400,
+        message: 'Validation failed',
+        details: error.details,
+      },
+    });
+  }
+
+  return next();
+};


### PR DESCRIPTION
Adicionado nova rota para retornar um podcast em específico baseado no id passado no route params da requisição

`/podcasts/{podcastId}`

Caso o podcast com esse id em específico não exista, ele retorna uma exception. O mesmo ocorre caso o podcast não esteja vinculado ao usuário que está fazendo a requisição.