### PR TITLE
[API] RF08

### DIFF
--- a/api/__tests__/services/podcasts.service.test.ts
+++ b/api/__tests__/services/podcasts.service.test.ts
@@ -127,6 +127,45 @@ describe('PodcastsService', () => {
     expect(await podcastsService.addPodcast(userId, podcast)).toEqual(newPodcast);
   });
 
+  it('should update podcast', async () => {
+    const userId = 1;
+    const podcastId = 1;
+
+    const newPodcastInfo: Partial<IPodcast> = {
+      title: 'test2',
+      description: 'test',
+      publishedAt: new Date(),
+      fileUrl: 'http://test.com/test.mp3',
+      duration: 4237,
+    };
+
+    jest.spyOn(podcastsRepository, 'updateById').mockReturnValueOnce(Promise.resolve([1]) as any);
+
+    expect(await podcastsService.updatePodcastById(userId, podcastId, newPodcastInfo)).toEqual(1);
+  });
+
+  it('should throw exception when podcast not found on edit', async () => {
+    const userId = 1;
+    const podcastId = 1;
+
+    const newPodcastInfo: Partial<IPodcast> = {
+      title: 'test2',
+      description: 'test',
+      publishedAt: new Date(),
+      fileUrl: 'http://test.com/test.mp3',
+      duration: 4237,
+    };
+
+    jest.spyOn(podcastsRepository, 'updateById').mockReturnValueOnce(Promise.resolve([0]) as any);
+
+    try {
+      await podcastsService.updatePodcastById(userId, podcastId, newPodcastInfo);
+    } catch (error: any) {
+      expect(error.statusCode).toEqual(404);
+      expect(error.message).toEqual('Podcast not found');
+    }
+  });
+
   it('should delete podcast', async () => {
     const podcastId = 1;
     const userId = 1;

--- a/api/__tests__/services/podcasts.service.test.ts
+++ b/api/__tests__/services/podcasts.service.test.ts
@@ -99,7 +99,7 @@ describe('PodcastsService', () => {
       expect(error.statusCode).toEqual(403);
       expect(error.message).toEqual('This podcast is not linked to your account');
     }
-  })
+  });
 
   it('should add podcast', async () => {
     const userId = 1;
@@ -125,5 +125,28 @@ describe('PodcastsService', () => {
     jest.spyOn(podcastsRepository, 'add').mockReturnValueOnce(Promise.resolve(newPodcast) as any);
 
     expect(await podcastsService.addPodcast(userId, podcast)).toEqual(newPodcast);
-  })
+  });
+
+  it('should delete podcast', async () => {
+    const podcastId = 1;
+    const userId = 1;
+
+    jest.spyOn(podcastsRepository, 'deleteById').mockReturnValueOnce(Promise.resolve(1) as any);
+
+    expect(await podcastsService.deletePodcastById(userId, podcastId)).toEqual(1);
+  });
+
+  it('should throw exception when podcast not found on delete', async () => {
+    const podcastId = 1;
+    const userId = 1;
+
+    jest.spyOn(podcastsRepository, 'deleteById').mockReturnValueOnce(Promise.resolve(0) as any);
+
+    try {
+      await podcastsService.deletePodcastById(userId, podcastId);
+    } catch (error: any) {
+      expect(error.statusCode).toEqual(404);
+      expect(error.message).toEqual('Podcast not found');
+    }
+  });
 });

--- a/api/src/controllers/PodcastsController.ts
+++ b/api/src/controllers/PodcastsController.ts
@@ -46,6 +46,21 @@ const addPodcast = async (req: Request<{}, {}, IPodcast>, res: Response) => {
   }
 };
 
+const updatePodcastById = async (req: Request, res: Response) => {
+  const { podcastId } = req.params;
+  try {
+    await podcastsService.updatePodcastById(req.userId, Number(podcastId), req.body as Partial<IPodcast>);
+    res.status(200).send();
+  } catch (error: any) {
+    res.status(error.statusCode).send({
+      error: {
+        statusCode: error.statusCode,
+        message: error.message,
+      },
+    });
+  }
+};
+
 const deletePodcastById = async (req: Request, res: Response) => {
   const { podcastId } = req.params;
   try {
@@ -65,5 +80,6 @@ export default {
   listPodcastsByUser,
   getPodcastById,
   addPodcast,
+  updatePodcastById,
   deletePodcastById,
 };

--- a/api/src/controllers/PodcastsController.ts
+++ b/api/src/controllers/PodcastsController.ts
@@ -44,10 +44,26 @@ const addPodcast = async (req: Request<{}, {}, IPodcast>, res: Response) => {
       },
     });
   }
-}
+};
+
+const deletePodcastById = async (req: Request, res: Response) => {
+  const { podcastId } = req.params;
+  try {
+    await podcastsService.deletePodcastById(req.userId, Number(podcastId));
+    res.status(200).send();
+  } catch (error: any) {
+    res.status(error.statusCode).send({
+      error: {
+        statusCode: error.statusCode,
+        message: error.message,
+      },
+    });
+  }
+};
 
 export default {
   listPodcastsByUser,
   getPodcastById,
   addPodcast,
+  deletePodcastById,
 };

--- a/api/src/repositories/podcasts.repository.ts
+++ b/api/src/repositories/podcasts.repository.ts
@@ -16,8 +16,13 @@ const add = async (userId: number, podcast: IPodcast) => {
   });
 };
 
+const deleteById = async (userId:number, podcastId: number) => {
+  return Podcast.destroy({ where: { id: podcastId, userId } });
+}
+
 export default {
   listByUserId,
   getById,
   add,
+  deleteById,
 };

--- a/api/src/repositories/podcasts.repository.ts
+++ b/api/src/repositories/podcasts.repository.ts
@@ -16,13 +16,18 @@ const add = async (userId: number, podcast: IPodcast) => {
   });
 };
 
-const deleteById = async (userId:number, podcastId: number) => {
+const updateById = async (userId: number, podcastId: number, podcast: Partial<IPodcast>) => {
+  return Podcast.update(podcast, { where: { id: podcastId, userId } });
+};
+
+const deleteById = async (userId: number, podcastId: number) => {
   return Podcast.destroy({ where: { id: podcastId, userId } });
-}
+};
 
 export default {
   listByUserId,
   getById,
   add,
+  updateById,
   deleteById,
 };

--- a/api/src/routes/podcasts.routes.ts
+++ b/api/src/routes/podcasts.routes.ts
@@ -5,6 +5,7 @@ import { addPodcastValidator } from '../validations/podcasts/addPodcast.validato
 import { deletePodcastValidator } from '../validations/podcasts/deletePodcast.validator';
 import { getPodcastByIdValidator } from '../validations/podcasts/getPodcastById.validator';
 import { listPodcastsByUserValidator } from '../validations/podcasts/listPodcastsByUser.validator';
+import { updatePodcastValidator } from '../validations/podcasts/updatePodcast.validator';
 
 const router = express.Router();
 
@@ -13,6 +14,7 @@ router.use(authValidator);
 router.get('/', listPodcastsByUserValidator, PodcastsController.listPodcastsByUser);
 router.get('/:podcastId', getPodcastByIdValidator, PodcastsController.getPodcastById);
 router.post('/', addPodcastValidator, PodcastsController.addPodcast);
+router.put('/:podcastId', updatePodcastValidator, PodcastsController.updatePodcastById);
 router.delete('/:podcastId', deletePodcastValidator, PodcastsController.deletePodcastById);
 
 export default router;

--- a/api/src/routes/podcasts.routes.ts
+++ b/api/src/routes/podcasts.routes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import PodcastsController from '../controllers/PodcastsController';
 import { authValidator } from '../validations/auth/auth.validator';
 import { addPodcastValidator } from '../validations/podcasts/addPodcast.validator';
+import { deletePodcastValidator } from '../validations/podcasts/deletePodcast.validator';
 import { getPodcastByIdValidator } from '../validations/podcasts/getPodcastById.validator';
 import { listPodcastsByUserValidator } from '../validations/podcasts/listPodcastsByUser.validator';
 
@@ -12,5 +13,6 @@ router.use(authValidator);
 router.get('/', listPodcastsByUserValidator, PodcastsController.listPodcastsByUser);
 router.get('/:podcastId', getPodcastByIdValidator, PodcastsController.getPodcastById);
 router.post('/', addPodcastValidator, PodcastsController.addPodcast);
+router.delete('/:podcastId', deletePodcastValidator, PodcastsController.deletePodcastById);
 
 export default router;

--- a/api/src/services/podcasts.service.ts
+++ b/api/src/services/podcasts.service.ts
@@ -31,8 +31,22 @@ const addPodcast = async (userId: number, podcast: IPodcast) => {
   return newPodcast;
 };
 
+const deletePodcastById = async (userId: number, podcastId: number) => {
+  const deletedPodcast = await podcastsRepository.deleteById(userId, podcastId);
+
+  if (deletedPodcast === 0) {
+    throw new Exception({
+      status: 404,
+      message: 'Podcast not found',
+    });
+  }
+
+  return deletedPodcast;
+};
+
 export default {
   listPodcastsByUser,
   getPodcastById,
   addPodcast,
+  deletePodcastById,
 };

--- a/api/src/services/podcasts.service.ts
+++ b/api/src/services/podcasts.service.ts
@@ -31,6 +31,19 @@ const addPodcast = async (userId: number, podcast: IPodcast) => {
   return newPodcast;
 };
 
+const updatePodcastById = async (userId: number, podcastId: number, podcast: Partial<IPodcast>) => {
+  const [updatedPodcast] = await podcastsRepository.updateById(userId, podcastId, podcast);
+
+  if (updatedPodcast === 0) {
+    throw new Exception({
+      status: 404,
+      message: 'Podcast not found',
+    });
+  }
+
+  return updatedPodcast;
+};
+
 const deletePodcastById = async (userId: number, podcastId: number) => {
   const deletedPodcast = await podcastsRepository.deleteById(userId, podcastId);
 
@@ -48,5 +61,6 @@ export default {
   listPodcastsByUser,
   getPodcastById,
   addPodcast,
+  updatePodcastById,
   deletePodcastById,
 };

--- a/api/src/validations/podcasts/deletePodcast.validator.ts
+++ b/api/src/validations/podcasts/deletePodcast.validator.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+import Joi from 'joi';
+
+const schema = Joi.object({
+  podcastId: Joi.number().required(),
+});
+
+export const deletePodcastValidator = (req: Request, res: Response, next: NextFunction) => {
+  const { error } = schema.validate(req.params, { abortEarly: false, allowUnknown: true, stripUnknown: true });
+
+  if (error) {
+    return res.status(400).send({
+      error: {
+        statusCode: 400,
+        message: 'Validation failed',
+        details: error.details,
+      },
+    });
+  }
+
+  return next();
+};

--- a/api/src/validations/podcasts/updatePodcast.validator.ts
+++ b/api/src/validations/podcasts/updatePodcast.validator.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, Response } from 'express';
+import Joi from 'joi';
+
+const schema = Joi.object({
+  title: Joi.string(),
+  members: Joi.string(),
+  publishedAt: Joi.date(),
+  thumbnail: Joi.string(),
+  description: Joi.string(),
+  fileUrl: Joi.string(),
+  duration: Joi.number(),
+});
+
+export const updatePodcastValidator = (req: Request, res: Response, next: NextFunction) => {
+  const { error } = schema.validate(req.body, { abortEarly: false, allowUnknown: true, stripUnknown: true });
+
+  if (error) {
+    return res.status(400).send({
+      error: {
+        statusCode: 400,
+        message: 'Validation failed',
+        details: error.details,
+      },
+    });
+  }
+
+  return next();
+};


### PR DESCRIPTION
Foi adicionado duas novas rotas:

`PUT /podcasts/{podcastId}` é responsável por atualizar as informações de um podcast, o payload é o mesmo da criação (PR #13), única diferença é que pode ser enviado somente os campos que foram alterados, isso é, um payload parcial. Ele retorna uma exception caso o podcast não esteja vinculado ao usuário que está fazendo a requisição.

`DELETE /podcasts/{podcastId}` é responsável por deletar o podcast do banco de dados. Ele retorna uma exception caso o podcast não esteja vinculado ao usuário que está fazendo a requisição.